### PR TITLE
migrate to latest nan

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,13 +30,13 @@
   "gypfile": true,
   "readmeFilename": "README.md",
   "dependencies": {
-    "bindings": "~1.1.1",
-    "debug": "^1.0.4",
-    "nan": "^1.7.0"
+    "bindings": "~1.2.1",
+    "debug": "^2.4.5",
+    "nan": "^2.4.0"
   },
   "devDependencies": {
-    "mocha": "^1.21.3",
-    "should": "^4.0.4",
-    "sinon": "^1.10.3"
+    "mocha": "^3.2.0",
+    "should": "^11.1.2",
+    "sinon": "^1.17.6"
   }
 }

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -10,12 +10,12 @@ using namespace node;
 using std::string;
 
 NAN_METHOD(eval) {
-    NanEscapableScope();
-    if (args.Length() < 1 || !args[0]->IsString()) {
-        NanThrowError("A string expression must be provided.");
+    Nan::EscapableHandleScope();
+    if (info.Length() < 1 || !info[0]->IsString()) {
+        Nan::ThrowError("A string expression must be provided.");
     }
 
-    PyCodeObject* code = (PyCodeObject*) Py_CompileString(*String::Utf8Value(args[0]->ToString()), "eval", Py_eval_input);
+    PyCodeObject* code = (PyCodeObject*) Py_CompileString(*String::Utf8Value(info[0]->ToString()), "eval", Py_eval_input);
     PyObject* main_module = PyImport_AddModule("__main__");
     PyObject* global_dict = PyModule_GetDict(main_module);
     PyObject* local_dict = PyDict_New();
@@ -27,41 +27,41 @@ NAN_METHOD(eval) {
     Py_XDECREF(local_dict);
     Py_XDECREF(obj);
 
-    NanEscapeScope(PyObjectWrapper::New(result));
+    PyObjectWrapper::New(result);
 }
 
 NAN_METHOD(finalize) {
-	NanScope();
+	Nan::HandleScope();
     Py_Finalize();
-    NanReturnUndefined();
+    Nan::Undefined();
 }
 
 NAN_METHOD(import) {
-    NanEscapableScope();
-    if (args.Length() < 1 || !args[0]->IsString()) {
-        NanThrowError("I don't know how to import that.");
+    Nan::EscapableHandleScope();
+    if (info.Length() < 1 || !info[0]->IsString()) {
+        Nan::ThrowError("I don't know how to import that.");
     }
 
     PyObject* module_name;
     PyObject* module;
 
-    module_name = PyUnicode_FromString(*String::Utf8Value(args[0]->ToString()));
+    module_name = PyUnicode_FromString(*String::Utf8Value(info[0]->ToString()));
     module = PyImport_Import(module_name);
 
     if (PyErr_Occurred()) {
-        NanReturnValue(ThrowPythonException());
+        Nan::ThrowError(ThrowPythonException());
     }
 
     if (!module) {
-        NanReturnValue(ThrowPythonException());
+        Nan::ThrowError(ThrowPythonException());
     }
     Py_XDECREF(module_name);
 
-    NanEscapeScope(PyObjectWrapper::New(module));
+    PyObjectWrapper::New(module);
 }
 
 void init (Handle<Object> exports) {
-    NanScope();
+    Nan::HandleScope();
 
     Py_Initialize();
     PyObjectWrapper::Initialize();
@@ -69,26 +69,26 @@ void init (Handle<Object> exports) {
     // how to schedule Py_Finalize(); to be called when process exits?
 
     // module.exports.eval
-    exports->Set(
-        NanNew<String>("eval"),
-        NanNew<FunctionTemplate>(eval)->GetFunction()
+    Nan::Set(
+        Nan::New<String>("eval"),
+        Nan::New<FunctionTemplate>(eval)->GetFunction()
     );
 
     // module.exports.finalize
-    exports->Set(
-        NanNew<String>("finalize"),
-        NanNew<FunctionTemplate>(finalize)->GetFunction()
+    Nan::Set(
+        Nan::New<String>("finalize"),
+        Nan::New<FunctionTemplate>(finalize)->GetFunction()
     );
 
     // module.exports.import
-    exports->Set(
-        NanNew<String>("import"),
-        NanNew<FunctionTemplate>(import)->GetFunction()
+    Nan::Set(
+        Nan::New<String>("import"),
+        Nan::New<FunctionTemplate>(import)->GetFunction()
     );
 
     // module.exports.PyObject
-    // exports->Set(
-    //     NanNew<String>("PyObject"),
+    // Nan::Set(
+    //     Nan::New<String>("PyObject"),
     //     PyObjectWrapper::py_function_template->GetFunction()
     // );
 

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -69,28 +69,16 @@ void init (Handle<Object> exports) {
     // how to schedule Py_Finalize(); to be called when process exits?
 
     // module.exports.eval
-    Nan::Set(
-        Nan::New<String>("eval"),
-        Nan::New<FunctionTemplate>(eval)->GetFunction()
-    );
+    Nan::Export(exports, "eval", eval);
 
     // module.exports.finalize
-    Nan::Set(
-        Nan::New<String>("finalize"),
-        Nan::New<FunctionTemplate>(finalize)->GetFunction()
-    );
+    Nan::Export(exports, "finalize", finalize);
 
     // module.exports.import
-    Nan::Set(
-        Nan::New<String>("import"),
-        Nan::New<FunctionTemplate>(import)->GetFunction()
-    );
+    Nan::Export(exports, "import", import);
 
     // module.exports.PyObject
-    // Nan::Set(
-    //     Nan::New<String>("PyObject"),
-    //     PyObjectWrapper::py_function_template->GetFunction()
-    // );
+    // Nan::Export(exports, "PyObject", PyObject);
 
 }
 

--- a/src/py_object_wrapper.cc
+++ b/src/py_object_wrapper.cc
@@ -54,7 +54,7 @@ Handle<Value> PyObjectWrapper::New(PyObject* obj) {
 
 NAN_GETTER(Get) {
     Nan::EscapableHandleScope();
-    PyObjectWrapper* wrapper = node::ObjectWrap::Unwrap<PyObjectWrapper>(args.This());
+    PyObjectWrapper* wrapper = node::ObjectWrap::Unwrap<PyObjectWrapper>(info.This());
     String::Utf8Value utf8_key(key);
     string value(*utf8_key);
     PyObject* result = wrapper->InstanceGet(value);
@@ -89,21 +89,21 @@ NAN_GETTER(ValueOfAccessor) {
 
 NAN_METHOD(PyObjectWrapper::Call) {
     Nan::EscapableHandleScope();
-    PyObjectWrapper* pyobjwrap = ObjectWrap::Unwrap<PyObjectWrapper>(args.This());
-    Handle<Value> result = pyobjwrap->InstanceCall(args);
+    PyObjectWrapper* pyobjwrap = ObjectWrap::Unwrap<PyObjectWrapper>(info.This());
+    Handle<Value> result = pyobjwrap->InstanceCall(info);
     Nan::EscapableHandleScope(result);
 }
 
 NAN_METHOD(PyObjectWrapper::ToString) {
     Nan::EscapableHandleScope;
-    PyObjectWrapper* pyobjwrap = ObjectWrap::Unwrap<PyObjectWrapper>(args.This());
-    Local<String> result = Nan::New<String>(pyobjwrap->InstanceToString(args).c_str());
+    PyObjectWrapper* pyobjwrap = ObjectWrap::Unwrap<PyObjectWrapper>(info.This());
+    Local<String> result = Nan::New<String>(pyobjwrap->InstanceToString(info).c_str());
     Nan::EscapableHandleScope(result);
 }
 
 NAN_METHOD(PyObjectWrapper::ValueOf) {
     Nan::EscapableHandleScope();
-    PyObjectWrapper* pyobjwrap = ObjectWrap::Unwrap<PyObjectWrapper>(args.This());
+    PyObjectWrapper* pyobjwrap = ObjectWrap::Unwrap<PyObjectWrapper>(info.This());
     PyObject* py_obj = pyobjwrap->InstanceGetPyObject();
     if(PyCallable_Check(py_obj)) {
         Local<FunctionTemplate> call = Nan::New<FunctionTemplate>(Call);
@@ -336,10 +336,10 @@ NAN_METHOD(PyObjectWrapper::InstanceCall) {
     // for now, we don't do anything.
     HandleScope scope;
 
-    int len = args.Length();
+    int len = info.Length();
     PyObject* args_tuple = PyTuple_New(len);
     for (int i = 0; i < len; ++i) {
-        PyTuple_SET_ITEM(args_tuple, i, ConvertToPython(args[i]));
+        PyTuple_SET_ITEM(args_tuple, i, ConvertToPython(info[i]));
     }
 
     PyObject* result = PyObject_CallObject(mPyObject, args_tuple);

--- a/src/py_object_wrapper.h
+++ b/src/py_object_wrapper.h
@@ -53,7 +53,7 @@ class PyObjectWrapper : public node::ObjectWrap {
 
         NAN_METHOD(InstanceCall);
 
-        string InstanceToString(_NAN_METHOD_ARGS_TYPE args);
+        string InstanceToString(Nan::NAN_METHOD_ARGS_TYPE args);
 
         PyObject* InstanceGet(const string& key);
 };

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -11,21 +11,21 @@ Handle<Value> ThrowPythonException() {
 
     // maybe useless to protect against bad use of ThrowPythonException ?
     if(pvalue == NULL) {
-        NanThrowError("No exception found");
+        Nan::ThrowError("No exception found");
     }
 
     // handle exception message
-    Local<v8::String> msg = NanNew<String>("Python Error: ");
+    Local<v8::String> msg = Nan::New<String>("Python Error: ");
 
     if (ptype != NULL) {
-        msg = v8::String::Concat(msg, NanNew<String>(PyString_AsString(PyObject_Str(PyObject_GetAttrString(ptype, "__name__")))));
-        msg = v8::String::Concat(msg, NanNew<String>(": "));
+        msg = v8::String::Concat(msg, Nan::New<String>(PyString_AsString(PyObject_Str(PyObject_GetAttrString(ptype, "__name__")))));
+        msg = v8::String::Concat(msg, Nan::New<String>(": "));
 
         if (pvalue != NULL) {
-            msg = v8::String::Concat(msg, NanNew<String>(PyString_AsString(PyObject_Str(pvalue))));
+            msg = v8::String::Concat(msg, Nan::New<String>(PyString_AsString(PyObject_Str(pvalue))));
         }
 
-        msg = v8::String::Concat(msg, NanNew<String>("\n"));
+        msg = v8::String::Concat(msg, Nan::New<String>("\n"));
     }
 
     if (ptraceback != NULL) {
@@ -55,11 +55,11 @@ Handle<Value> ThrowPythonException() {
             Py_DECREF(pystr);
             Py_DECREF(str);
 
-            msg = v8::String::Concat(msg, NanNew<String>("\n"));
-            msg = v8::String::Concat(msg, NanNew<String>(full_backtrace));
+            msg = v8::String::Concat(msg, Nan::New<String>("\n"));
+            msg = v8::String::Concat(msg, Nan::New<String>(full_backtrace));
         } else {
-            msg = v8::String::Concat(msg, NanNew<String>("\n"));
-            msg = v8::String::Concat(msg, NanNew<String>(PyString_AsString(PyObject_Str(ptraceback))));
+            msg = v8::String::Concat(msg, Nan::New<String>("\n"));
+            msg = v8::String::Concat(msg, Nan::New<String>(PyString_AsString(PyObject_Str(ptraceback))));
         }
 
     }
@@ -84,5 +84,5 @@ Handle<Value> ThrowPythonException() {
     Py_XDECREF(pvalue);
     Py_XDECREF(ptraceback);
 
-    NanThrowError(err);
+    Nan::ThrowError(err);
 }

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -15,7 +15,7 @@ Handle<Value> ThrowPythonException() {
     }
 
     // handle exception message
-    Local<v8::String> msg = Nan::New<String>("Python Error: ");
+    Local<v8::String> msg = Nan::New<String>("Python Error: ").ToLocalChecked();
 
     if (ptype != NULL) {
         msg = v8::String::Concat(msg, Nan::New<String>(PyString_AsString(PyObject_Str(PyObject_GetAttrString(ptype, "__name__")))));

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -18,14 +18,14 @@ Handle<Value> ThrowPythonException() {
     Local<v8::String> msg = Nan::New<String>("Python Error: ").ToLocalChecked();
 
     if (ptype != NULL) {
-        msg = v8::String::Concat(msg, Nan::New<String>(PyString_AsString(PyObject_Str(PyObject_GetAttrString(ptype, "__name__")))));
-        msg = v8::String::Concat(msg, Nan::New<String>(": "));
+        msg = v8::String::Concat(msg, Nan::New<String>(PyString_AsString(PyObject_Str(PyObject_GetAttrString(ptype, "__name__")))).ToLocalChecked());
+        msg = v8::String::Concat(msg, Nan::New<String>(": ").ToLocalChecked());
 
         if (pvalue != NULL) {
-            msg = v8::String::Concat(msg, Nan::New<String>(PyString_AsString(PyObject_Str(pvalue))));
+            msg = v8::String::Concat(msg, Nan::New<String>(PyString_AsString(PyObject_Str(pvalue))).ToLocalChecked());
         }
 
-        msg = v8::String::Concat(msg, Nan::New<String>("\n"));
+        msg = v8::String::Concat(msg, Nan::New<String>("\n").ToLocalChecked());
     }
 
     if (ptraceback != NULL) {
@@ -55,11 +55,11 @@ Handle<Value> ThrowPythonException() {
             Py_DECREF(pystr);
             Py_DECREF(str);
 
-            msg = v8::String::Concat(msg, Nan::New<String>("\n"));
-            msg = v8::String::Concat(msg, Nan::New<String>(full_backtrace));
+            msg = v8::String::Concat(msg, Nan::New<String>("\n").ToLocalChecked());
+            msg = v8::String::Concat(msg, Nan::New<String>(full_backtrace).ToLocalChecked());
         } else {
-            msg = v8::String::Concat(msg, Nan::New<String>("\n"));
-            msg = v8::String::Concat(msg, Nan::New<String>(PyString_AsString(PyObject_Str(ptraceback))));
+            msg = v8::String::Concat(msg, Nan::New<String>("\n").ToLocalChecked());
+            msg = v8::String::Concat(msg, Nan::New<String>(PyString_AsString(PyObject_Str(ptraceback))).ToLocalChecked());
         }
 
     }

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,4 +1,3 @@
-
 #include <v8.h>
 #include <nan.h>
 


### PR DESCRIPTION
Currently the lib is failing to install due to incompatibility. Started making changes as per the new NAN.

pending with bunch of errors like - 

```
  CXX(target) Release/obj.target/binding/src/py_object_wrapper.o
../src/py_object_wrapper.cc:22:38: error: cannot initialize a parameter of type 'NamedPropertyGetterCallback' (aka 'void (*)(Local<v8::String>, const
      PropertyCallbackInfo<v8::Value> &)') with an lvalue of type 'Nan::NAN_GETTER_RETURN_TYPE (v8::Local<v8::String>, Nan::NAN_GETTER_ARGS_TYPE)' (aka 'void
      (Local<v8::String>, const PropertyCallbackInfo<v8::Value> &)'): type mismatch at 2nd parameter ('const PropertyCallbackInfo<v8::Value> &'
      (aka 'const v8::PropertyCallbackInfo<v8::Value> &') vs 'Nan::NAN_GETTER_ARGS_TYPE' (aka 'const PropertyCallbackInfo<v8::Value> &'))
    obj_tpl->SetNamedPropertyHandler(Get, Set);
                                     ^~~
```


Any help in fixing these errors is much appreciated.
